### PR TITLE
Add more control over the opacity range of areas in the map (optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ The key is a country's [ISO 3166 Code](https://en.wikipedia.org/wiki/ISO_3166). 
 
 | Name                    | Type                                                                                   | Description                                                                     | Default              | Required |
 |-------------------------|----------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|----------------------|----------|
-| data                    |  number / { value?: number, color?: string, legendLabel?: string }                     | See Usage Section above for details                                             | undefined            | Yes      |
+| data                    | number / { value?: number, color?: string, legendLabel?: string }                      | See Usage Section above for details                                             | undefined            | Yes      |
 | type                    | 'world' / 'africa' / 'asia' / 'europe' / 'north-america' / 'south-america' / 'oceania' | Type of map displayed                                                           | 'world'              | No       |
 | baseColor               | string                                                                                 | Color use for data representation                                               | '#0782c5'            | No       |
 | langCode                | string                                                                                 | The language of countries name                                                  | 'en'                 | No       |
@@ -131,6 +131,7 @@ The key is a country's [ISO 3166 Code](https://en.wikipedia.org/wiki/ISO_3166). 
 | defaultFillHoverColor   | string                                                                                 | Default map fill hover color                                                    | 'rgb(226, 226, 226)' | No       |
 | formatValueWithSiPrefix | boolean                                                                                | Formats a number with a magnitude suffix                                        | false                | No       |
 | forceCursorPointer      | boolean                                                                                | Force the cursor to be in pointer mode even when the legend display is disabled | false                | No       |
+| minOpacity              | number                                                                                 | Minimum opacity of areas                                                        | 0.01                 | No       |
 
 ## Events
 

--- a/packages/vue3-map-chart/src/components/MapChart.vue
+++ b/packages/vue3-map-chart/src/components/MapChart.vue
@@ -40,6 +40,7 @@
     defaultFillHoverColor?: string
     baseColor?: string
     data: MapData
+    minOpacity: number
   }
 
   const props = withDefaults(defineProps<Props>(), {
@@ -61,6 +62,7 @@
     defaultStrokeHoverColor: 'rgb(200, 200, 200)',
     defaultStrokeColor: 'rgb(200, 200, 200)',
     baseColor: '#0782c5',
+    minOpacity: 0.01
   })
 
   onMounted(() => {
@@ -212,7 +214,7 @@
           opacity = 1
         } else {
           opacity = (value - min) / (max - min)
-          opacity = opacity == 0 ? 0.01 : opacity
+          opacity = opacity == 0 ? props.minOpacity : opacity
         }
         css.value += ` #v3mc-map-${cpntId} #${key.toUpperCase()} { fill: ${
           color || props.baseColor


### PR DESCRIPTION
Added a min-opacity prop to the component which overrides the default 0.01